### PR TITLE
Allow polyclip() to work with "open" shapes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: polyclip
-Version: 1.9-1
+Version: 1.91-0
 Date: 2018-07-25
 Title: Polygon Clipping
 Authors@R: c(person("Angus", "Johnson", role = "aut", 
@@ -9,9 +9,9 @@ Authors@R: c(person("Angus", "Johnson", role = "aut",
 	     person("Kurt", "Hornik", role = "ctb"),
 	     person(c("Brian", "D."), "Ripley", role = "ctb"),
 	     person("Elliott", "Sales de Andrade", role="ctb"))
-Maintainer: Adrian Baddeley <Adrian.Baddeley@curtin.edu.au>
+Maintainer: Paul Murrell <paul@stat.auckland.ac.nz>
 Depends: R (>= 3.0.0)
-Description: R port of Angus Johnson's open source library Clipper. Performs polygon clipping operations (intersection, union, set minus, set difference) for polygonal regions of arbitrary complexity, including holes. Computes offset polygons (spatial buffer zones, morphological dilations, Minkowski dilations) for polygonal regions and polygonal lines. Computes Minkowski Sum of general polygons. There is a function for removing self-intersections from polygon data.
+Description: A fork of Adrian Baddeley's github repo. R port of Angus Johnson's open source library Clipper. Performs polygon clipping operations (intersection, union, set minus, set difference) for polygonal regions of arbitrary complexity, including holes. Computes offset polygons (spatial buffer zones, morphological dilations, Minkowski dilations) for polygonal regions and polygonal lines. Computes Minkowski Sum of general polygons. There is a function for removing self-intersections from polygon data.
 License: BSL
 URL: http://www.angusj.com/delphi/clipper.php, https://sourceforge.net/projects/polyclipping, https://github.com/baddstats/polyclip
 BugReports: https://github.com/baddstats/polyclip/issues

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,8 @@
 
+        CHANGES IN polyclip VERSION 1.91-0
+
+    o 
+
         CHANGES IN polyclip VERSION 1.9-1
 
 SIGNIFICANT USER-VISIBLE CHANGES

--- a/R/clipper.R
+++ b/R/clipper.R
@@ -64,7 +64,8 @@ polyclip <-
            ...,
            eps, x0, y0,
            fillA=c("evenodd", "nonzero", "positive", "negative"),
-           fillB=c("evenodd", "nonzero", "positive", "negative")
+           fillB=c("evenodd", "nonzero", "positive", "negative"),
+           closed=TRUE
            ) {
     # validate parameters and convert to integer codes
     op <- match.arg(op)
@@ -82,6 +83,7 @@ polyclip <-
       if(validxy(B)) B <- list(B) else
       stop("Argument B should be a list of lists, each containing vectors x,y")
     }
+    # 
     # determine value of 'eps' if missing
     if(missing(eps) || missing(x0) || missing(y0)) {
       xr <- range(range(unlist(lapply(A, xrange))),
@@ -97,9 +99,10 @@ polyclip <-
     B <- ensuredouble(B)
     storage.mode(ct) <- storage.mode(pftA) <- storage.mode(pftB) <- "integer"
     storage.mode(x0) <- storage.mode(y0) <- storage.mode(eps) <- "double"
+    storage.mode(closed) <- "logical"
     ans <- .Call(eCclipbool,
                  A, B, pftA, pftB, ct,
-                 x0, y0, eps,
+                 x0, y0, eps, closed,
                  PACKAGE="polyclip")
     return(aspolygonlist(ans))
   }

--- a/man/polyclip.Rd
+++ b/man/polyclip.Rd
@@ -9,7 +9,8 @@
          \dots,
          eps, x0, y0,
          fillA=c("evenodd", "nonzero", "positive", "negative"),
-         fillB=c("evenodd", "nonzero", "positive", "negative"))
+         fillB=c("evenodd", "nonzero", "positive", "negative"),
+         closed = TRUE)
 }
 \arguments{
   \item{A,B}{
@@ -20,6 +21,7 @@
   \item{eps}{Spatial resolution for coordinates.}
   \item{x0,y0}{Spatial origin for coordinates.}
   \item{fillA,fillB}{Polygon-filling rule for \code{A} and \code{B}.}
+  \item{closed}{Whether \code{A} is a closed shape or an open shape (a line).}
 }
 \value{
   Data specifying polygons, in the same format as \code{A} and \code{B}.

--- a/src/init.c
+++ b/src/init.c
@@ -22,7 +22,8 @@ SEXP Cclipbool(SEXP A,
 	       SEXP ct,
 	       SEXP X0,
 	       SEXP Y0,
-	       SEXP Eps); 
+	       SEXP Eps,
+               SEXP clo); 
 
 SEXP Cpolyoffset(SEXP A,
 		 SEXP del,
@@ -62,7 +63,7 @@ static const R_CMethodDef CEntries[] = {
   
 static const R_CallMethodDef CallEntries[] = {
     {"Csimplify",        (DL_FUNC) &Csimplify,         5},
-    {"Cclipbool",        (DL_FUNC) &Cclipbool,         8},
+    {"Cclipbool",        (DL_FUNC) &Cclipbool,         9},
     {"Cpolyoffset",      (DL_FUNC) &Cpolyoffset,       8},
     {"Clineoffset",      (DL_FUNC) &Clineoffset,       9},
     {"Cminksum",         (DL_FUNC) &Cminksum,          6},


### PR DESCRIPTION
Hi 

For my 'gridGeometry' package, I created a fork of 'polyclip' that could work with "open" shapes (lines) as well as (closed) polygons.  

Would you consider adding this to the real 'polyclip' ?

I have tried to make the patch low-impact (and you can ignore the DESCRIPTION file and the NEWS file).  There is just a new 'closed' argument to polyclip().  So you can treat 'A' as either closed or open.

It would be more flexible to allow 'A' to be a combination of closed and open shapes (which I believe Clipper can handle), but that would require much larger and more invasive changes.

Keen to hear what you think

Paul